### PR TITLE
feat: add unity RequireComponent compatibility

### DIFF
--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -244,31 +244,31 @@ export const errors = {
 		];
 	}),
 
-	requiredComponentTypeParameterRequired: errorWithContext((methodName: string) => {
+	requiredComponentTypeParameterRequired: errorWithContext((className: string) => {
 		return [
-			`Macro ${methodName}<T>() requires a type argument at T`,
-			suggestion("Try adding a type argument to the function call"),
+			`@RequireComponent decorator on class '${className}' requires at least one type parameter`,
+			suggestion("Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour"),
 		];
 	}),
 
 	requiredComponentArgumentRequired: errorWithContext((className: string) => {
 		return [
-			`@RequireComponent decorator on class '${className}' requires at least one component type argument`,
-			suggestion("Use @RequireComponent(typeof(ComponentType)) where ComponentType is a Unity component or AirshipBehaviour"),
+			`@RequireComponent decorator on class '${className}' requires at least one type parameter`,
+			suggestion("Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour"),
 		];
 	}),
 
 	requiredComponentInvalidType: errorWithContext((className: string, typeName: string) => {
 		return [
 			`@RequireComponent decorator on class '${className}' received invalid component type '${typeName}'`,
-			suggestion("Component type must be a Unity component or AirshipBehaviour. Try @RequireComponent(typeof(ValidComponentType))"),
+			suggestion("Component type must be a Unity component or AirshipBehaviour. Try @RequireComponent<ValidComponentType>()"),
 		];
 	}),
 
 	requiredComponentInvalidArgument: errorWithContext((className: string, argumentType: string) => {
 		return [
 			`@RequireComponent decorator on class '${className}' received invalid argument of type '${argumentType}'`,
-			suggestion("Use @RequireComponent(typeof(ComponentType)) where ComponentType is a Unity component or AirshipBehaviour"),
+			suggestion("Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour"),
 		];
 	}),
 

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -244,6 +244,34 @@ export const errors = {
 		];
 	}),
 
+	requiredComponentTypeParameterRequired: errorWithContext((methodName: string) => {
+		return [
+			`Macro ${methodName}<T>() requires a type argument at T`,
+			suggestion("Try adding a type argument to the function call"),
+		];
+	}),
+
+	requiredComponentArgumentRequired: errorWithContext((className: string) => {
+		return [
+			`@RequireComponent decorator on class '${className}' requires at least one component type argument`,
+			suggestion("Use @RequireComponent(typeof(ComponentType)) where ComponentType is a Unity component or AirshipBehaviour"),
+		];
+	}),
+
+	requiredComponentInvalidType: errorWithContext((className: string, typeName: string) => {
+		return [
+			`@RequireComponent decorator on class '${className}' received invalid component type '${typeName}'`,
+			suggestion("Component type must be a Unity component or AirshipBehaviour. Try @RequireComponent(typeof(ValidComponentType))"),
+		];
+	}),
+
+	requiredComponentInvalidArgument: errorWithContext((className: string, argumentType: string) => {
+		return [
+			`@RequireComponent decorator on class '${className}' received invalid argument of type '${argumentType}'`,
+			suggestion("Use @RequireComponent(typeof(ComponentType)) where ComponentType is a Unity component or AirshipBehaviour"),
+		];
+	}),
+
 	unityMacroTypeArgumentRequired: errorWithContext((methodName: string) => {
 		return [
 			`Macro ${methodName}<T>() requires a type argument at T`,
@@ -252,7 +280,7 @@ export const errors = {
 	}),
 
 	decoratorParamsLiteralsOnly: error(
-		"Airship Behaviour decorators only accept literal `string`, `boolean` or `number` values",
+		"Airship Behaviour decorators only accept literal `string`, `boolean` or `number` values. For RequireComponent, use `typeof(ComponentType)` syntax.",
 	),
 
 	// files

--- a/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
+++ b/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
@@ -630,13 +630,13 @@ function processRequireComponentDecorator(
 
 	const componentParameters = new Array<AirshipBehaviourFieldDecoratorParameter>();
 	for (const argument of decoratorArguments) {
-		if (!ts.isIdentifier(argument)) {
+		if (!ts.isTypeOfExpression(argument)) {
 			const argumentType = typeChecker.typeToString(typeChecker.getTypeAtLocation(argument));
 			DiagnosticService.addDiagnostic(errors.requiredComponentInvalidArgument(classNode, classNode.name?.text ?? "<anonymous>", argumentType));
 			continue;
 		}
 
-		let type = typeChecker.getTypeAtLocation(argument);
+		let type = typeChecker.getTypeAtLocation(argument.expression);
 
 		const constructSignatures = type.getConstructSignatures();
 		if (constructSignatures.length > 0) {

--- a/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
+++ b/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
@@ -621,28 +621,16 @@ function processRequireComponentDecorator(
 	expression: ts.CallExpression,
 ): AirshipBehaviourClassDecorator | undefined {
 	const typeChecker = state.typeChecker;
-	const decoratorArguments = expression.arguments;
+	const typeArguments = expression.typeArguments;
 	
-	if (!decoratorArguments || decoratorArguments.length === 0) {
-		DiagnosticService.addDiagnostic(errors.requiredComponentArgumentRequired(classNode, classNode.name?.text || "<anonymous>"));
+	if (!typeArguments || typeArguments.length === 0) {
+		DiagnosticService.addDiagnostic(errors.requiredComponentTypeParameterRequired(classNode, classNode.name?.text || "<anonymous>"));
 		return undefined;
 	}
 
 	const componentParameters = new Array<AirshipBehaviourFieldDecoratorParameter>();
-	for (const argument of decoratorArguments) {
-		if (!ts.isTypeOfExpression(argument)) {
-			const argumentType = typeChecker.typeToString(typeChecker.getTypeAtLocation(argument));
-			DiagnosticService.addDiagnostic(errors.requiredComponentInvalidArgument(classNode, classNode.name?.text ?? "<anonymous>", argumentType));
-			continue;
-		}
-
-		let type = typeChecker.getTypeAtLocation(argument.expression);
-
-		const constructSignatures = type.getConstructSignatures();
-		if (constructSignatures.length > 0) {
-			const constructSignature = constructSignatures[0];
-			type = typeChecker.getReturnTypeOfSignature(constructSignature);
-		}
+	for (const typeArgument of typeArguments) {
+		const type = typeChecker.getTypeFromTypeNode(typeArgument);
 
 		if (isAirshipBehaviourType(state, type)) {
 			const typeString = typeChecker.typeToString(type);


### PR DESCRIPTION
Based on the unity [documentation reference](https://docs.unity3d.com/ScriptReference/RequireComponent.html), the new RequireComponent decorator was implemented.

Generated decorators metadata:
<img width="1454" height="1202" alt="image" src="https://github.com/user-attachments/assets/8316a5a0-703c-4988-a147-8edf9393c79d" />