### PR TITLE
Add support for splitting server/client code

### DIFF
--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -57,8 +57,8 @@ export = ts.identity<yargs.CommandModule<{}, BuildFlags & Partial<ProjectOptions
 			default: false,
 		},
 		publish: {
-			// hidden: true,
 			alias: "D",
+			hidden: true,
 			boolean: true,
 			default: false,
 		},

--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -20,7 +20,7 @@ import { ProjectOptions, TypeScriptConfiguration } from "Shared/types";
 import { getRootDirs } from "Shared/util/getRootDirs";
 import { hasErrors } from "Shared/util/hasErrors";
 import { AirshipBuildState, BUILD_FILE, EDITOR_FILE } from "TSTransformer";
-import ts, { TSConfig } from "typescript";
+import ts from "typescript";
 import yargs from "yargs";
 
 interface BuildFlags {

--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -1,8 +1,9 @@
 import { findTsConfigPath, getPackageJson, getTsConfigProjectOptions } from "CLI/util/findTsConfigPath";
 import { existsSync } from "fs";
+import path from "path";
 import { buildTypes } from "Project/functions/buildTypes";
 import { cleanup } from "Project/functions/cleanup";
-import { compileFiles } from "Project/functions/compileFiles";
+import { compileFiles, isPackage } from "Project/functions/compileFiles";
 import { copyFiles } from "Project/functions/copyFiles";
 import { copyNodeModules } from "Project/functions/copyInclude";
 import { createPathTranslator } from "Project/functions/createPathTranslator";
@@ -43,12 +44,6 @@ export = ts.identity<yargs.CommandModule<{}, BuildFlags & Partial<ProjectOptions
 			default: ".",
 			describe: "project path",
 		},
-		// dist: {
-		// 	alias: "D",
-		// 	choices: ["server", "client", "shared"],
-		// 	describe: "The distribution of this compile",
-		// 	default: "shared",
-		// },
 		skipPackages: {
 			type: "boolean",
 			alias: "P",
@@ -162,7 +157,15 @@ export = ts.identity<yargs.CommandModule<{}, BuildFlags & Partial<ProjectOptions
 					pathTranslator,
 					new Set(getRootDirs(program.getCompilerOptions(), data.projectOptions)),
 				);
-				const sourceFiles = getChangedSourceFiles(program);
+
+				let sourceFiles = getChangedSourceFiles(program);
+
+				if (projectOptions.skipPackages) {
+					LogService.writeIfVerbose("Filtering out packages from compile");
+					sourceFiles = sourceFiles.filter(
+						sourceFile => !isPackage(path.relative(process.cwd(), sourceFile.fileName)),
+					);
+				}
 
 				if (projectOptions.json) {
 					jsonReporter("startingCompile", { initial: true, count: sourceFiles.length });

--- a/src/CLI/commands/build.ts
+++ b/src/CLI/commands/build.ts
@@ -43,13 +43,27 @@ export = ts.identity<yargs.CommandModule<{}, BuildFlags & Partial<ProjectOptions
 			default: ".",
 			describe: "project path",
 		},
+		// dist: {
+		// 	alias: "D",
+		// 	choices: ["server", "client", "shared"],
+		// 	describe: "The distribution of this compile",
+		// 	default: "shared",
+		// },
+		skipPackages: {
+			type: "boolean",
+			alias: "P",
+			describe: "Compile only the game's code",
+			boolean: true,
+			default: false,
+		},
 		json: {
 			hidden: true,
 			boolean: true,
 			default: false,
 		},
 		publish: {
-			hidden: true,
+			// hidden: true,
+			alias: "D",
 			boolean: true,
 			default: false,
 		},

--- a/src/Project/functions/compileFiles.ts
+++ b/src/Project/functions/compileFiles.ts
@@ -11,7 +11,7 @@ import { createTransformerWatcher } from "Project/transformers/createTransformer
 import { getPluginConfigs } from "Project/transformers/getPluginConfigs";
 import { getCustomPreEmitDiagnostics } from "Project/util/getCustomPreEmitDiagnostics";
 import { LogService } from "Shared/classes/LogService";
-import { PathTranslator } from "Shared/classes/PathTranslator";
+import { PathHint, PathTranslator } from "Shared/classes/PathTranslator";
 import { ProjectType } from "Shared/constants";
 import { warnings } from "Shared/diagnostics";
 import { AirshipBuildFile, ProjectData } from "Shared/types";
@@ -20,6 +20,7 @@ import { benchmarkIfVerbose } from "Shared/util/benchmark";
 import {
 	AirshipBuildState,
 	BUILD_FILE,
+	CompliationContext,
 	EDITOR_FILE,
 	MultiTransformState,
 	transformSourceFile,
@@ -46,6 +47,10 @@ function getReverseSymlinkMap(program: ts.Program) {
 	return result;
 }
 
+export function isPackage(relativePath: string) {
+	return relativePath.startsWith("AirshipPackages" + path.sep);
+}
+
 /**
  * 'transpiles' TypeScript project into a logically identical Luau project.
  *
@@ -58,7 +63,7 @@ export function compileFiles(
 	buildState: AirshipBuildState,
 	sourceFiles: Array<ts.SourceFile>,
 ): ts.EmitResult {
-	const asJson = data.projectOptions.json;
+	const { json: asJson, publish: isPublish } = data.projectOptions;
 	const compilerOptions = program.getCompilerOptions();
 
 	const watch = compilerOptions.watch ?? false;
@@ -92,7 +97,7 @@ export function compileFiles(
 
 	LogService.writeLineIfVerbose(`Now running TypeScript compiler:`);
 
-	const fileWriteQueue = new Array<{ sourceFile: ts.SourceFile; source: string }>();
+	const fileWriteQueue = new Array<{ sourceFile: ts.SourceFile; source: string; context?: CompliationContext }>();
 	const fileMetadataWriteQueue = new Map<ts.SourceFile, string>();
 
 	const progressMaxLength = `${sourceFiles.length}/${sourceFiles.length}`.length;
@@ -179,7 +184,9 @@ export function compileFiles(
 		const sourceFile = proxyProgram.getSourceFile(sourceFiles[i].fileName);
 		assert(sourceFile);
 		const progress = `${i + 1}/${sourceFiles.length}`.padStart(progressMaxLength);
-		benchmarkIfVerbose(`${progress} compile ${path.relative(process.cwd(), sourceFile.fileName)}`, () => {
+		const relativePath = path.relative(process.cwd(), sourceFile.fileName);
+
+		benchmarkIfVerbose(`${progress} compile ${relativePath}`, () => {
 			DiagnosticService.addDiagnostics(ts.getPreEmitDiagnostics(proxyProgram, sourceFile));
 			DiagnosticService.addDiagnostics(getCustomPreEmitDiagnostics(data, sourceFile));
 			if (DiagnosticService.hasErrors()) return;
@@ -200,12 +207,27 @@ export function compileFiles(
 				sourceFile,
 			);
 
-			const luauAST = transformSourceFile(transformState, sourceFile);
-			if (DiagnosticService.hasErrors()) return;
+			if (isPublish && !isPackage(relativePath)) {
+				transformState.useContext(CompliationContext.Server, context => {
+					const luauAST = transformSourceFile(transformState, sourceFile);
+					if (DiagnosticService.hasErrors()) return;
+					const source = renderAST(luauAST);
+					fileWriteQueue.push({ sourceFile, source, context });
+				});
 
-			const source = renderAST(luauAST);
-
-			fileWriteQueue.push({ sourceFile, source });
+				if (DiagnosticService.hasErrors()) return;
+				transformState.useContext(CompliationContext.Client, context => {
+					const luauAST = transformSourceFile(transformState, sourceFile);
+					if (DiagnosticService.hasErrors()) return;
+					const source = renderAST(luauAST);
+					fileWriteQueue.push({ sourceFile, source, context });
+				});
+			} else {
+				const luauAST = transformSourceFile(transformState, sourceFile);
+				if (DiagnosticService.hasErrors()) return;
+				const source = renderAST(luauAST);
+				fileWriteQueue.push({ sourceFile, source });
+			}
 
 			const airshipBehaviours = transformState.airshipBehaviours;
 
@@ -231,7 +253,8 @@ export function compileFiles(
 					const airshipBehaviourMetadata = behaviour.metadata;
 
 					if (airshipBehaviourMetadata) {
-						assert(!fileMetadataWriteQueue.has(sourceFile));
+						if (fileMetadataWriteQueue.has(sourceFile)) continue;
+
 						fileMetadataWriteQueue.set(sourceFile, JSON.stringify(airshipBehaviourMetadata, null, "\t"));
 					}
 
@@ -263,8 +286,20 @@ export function compileFiles(
 			let writeCount = 0;
 			let metadataCount = 0;
 
-			for (const { sourceFile, source } of fileWriteQueue) {
-				const outPath = pathTranslator.getOutputPath(sourceFile.fileName);
+			for (const { sourceFile, source, context } of fileWriteQueue) {
+				let pathHint: PathHint | undefined;
+				if (context !== undefined) {
+					switch (context) {
+						case CompliationContext.Client:
+							pathHint = PathHint.Client;
+							break;
+						case CompliationContext.Server:
+							pathHint = PathHint.Server;
+							break;
+					}
+				}
+
+				const outPath = pathTranslator.getOutputPath(sourceFile.fileName, pathHint);
 				const hasMetadata = fileMetadataWriteQueue.has(sourceFile);
 				const metadataPathOutPath = outPath + ".json~";
 

--- a/src/Project/functions/compileFiles.ts
+++ b/src/Project/functions/compileFiles.ts
@@ -186,6 +186,17 @@ export function compileFiles(
 		});
 	}
 
+	if (isPublish) {
+		const sharedDirectory = pathTranslator.getOutDir(PathHint.Shared);
+		if (fs.pathExistsSync(sharedDirectory)) fs.removeSync(sharedDirectory);
+
+		const clientDirectory = pathTranslator.getOutDir(PathHint.Client);
+		if (fs.pathExistsSync(clientDirectory)) fs.removeSync(clientDirectory);
+
+		const serverDirectory = pathTranslator.getOutDir(PathHint.Server);
+		if (fs.pathExistsSync(serverDirectory)) fs.removeSync(serverDirectory);
+	}
+
 	for (let i = 0; i < sourceFiles.length; i++) {
 		const sourceFile = proxyProgram.getSourceFile(sourceFiles[i].fileName);
 		assert(sourceFile);

--- a/src/Shared/classes/PathTranslator.ts
+++ b/src/Shared/classes/PathTranslator.ts
@@ -41,6 +41,7 @@ export enum PathHint {
 	None,
 	Server,
 	Client,
+	Shared,
 }
 
 type PathInfoDelegate = (pathInfo: PathInfo) => string;
@@ -84,6 +85,8 @@ export class PathTranslator {
 			makeRelative = this.makeRelativeFactory(undefined, path.resolve(this.outDir, "../dist/server"));
 		} else if (pathHint === PathHint.Client) {
 			makeRelative = this.makeRelativeFactory(undefined, path.resolve(this.outDir, "../dist/client"));
+		} else if (pathHint === PathHint.Shared) {
+			makeRelative = this.makeRelativeFactory(undefined, path.resolve(this.outDir, "../dist/shared"));
 		} else {
 			makeRelative = this.makeRelativeFactory();
 		}

--- a/src/Shared/classes/PathTranslator.ts
+++ b/src/Shared/classes/PathTranslator.ts
@@ -72,6 +72,18 @@ export class PathTranslator {
 	// 	return unityPath;
 	// }
 
+	public getOutDir(pathHint = PathHint.None) {
+		if (pathHint === PathHint.Server) {
+			return path.resolve(this.outDir, "../dist/server");
+		} else if (pathHint === PathHint.Client) {
+			return path.resolve(this.outDir, "../dist/client");
+		} else if (pathHint === PathHint.Shared) {
+			return path.resolve(this.outDir, "../dist/shared");
+		} else {
+			return this.outDir;
+		}
+	}
+
 	/**
 	 * Maps an input path to an output path
 	 * - `.tsx?` && !`.d.tsx?` -> `.lua`

--- a/src/Shared/constants.ts
+++ b/src/Shared/constants.ts
@@ -52,6 +52,7 @@ export const DEFAULT_PROJECT_OPTIONS: ProjectOptions = {
 	usePolling: false,
 	json: false,
 	verbose: false,
+	skipPackages: false,
 	noInclude: false,
 	logTruthyChanges: false,
 	incremental: undefined,

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -325,10 +325,6 @@ export const errors = {
 		"$CLIENT is a directive macro and can only be used as a top-level condition in an if statement - e.g. if ($CLIENT)",
 	),
 
-	inverseGuardClause: error(
-		"Inverse guard clauses are not supported with directives, please reverse the flow of the guard clause.",
-	),
-
 	flameworkIdNoType: errorWithContext(() => {
 		return [
 			"Macro Flamework.id<T> requires a type argument at T",

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -325,6 +325,10 @@ export const errors = {
 		"$CLIENT is a directive macro and can only be used as a top-level condition in an if statement - e.g. if ($CLIENT)",
 	),
 
+	inverseGuardClause: error(
+		"Inverse guard clauses are not supported with directives, please reverse the flow of the guard clause.",
+	),
+
 	flameworkIdNoType: errorWithContext(() => {
 		return [
 			"Macro Flamework.id<T> requires a type argument at T",

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -244,33 +244,41 @@ export const errors = {
 		];
 	}),
 
-	invalidServerMacroUse:error("invalid"),
+	invalidServerMacroUse: error("invalid"),
 
 	requiredComponentTypeParameterRequired: errorWithContext((className: string) => {
 		return [
 			`@RequireComponent decorator on class '${className}' requires at least one type parameter`,
-			suggestion("Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour"),
+			suggestion(
+				"Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour",
+			),
 		];
 	}),
 
 	requiredComponentArgumentRequired: errorWithContext((className: string) => {
 		return [
 			`@RequireComponent decorator on class '${className}' requires at least one type parameter`,
-			suggestion("Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour"),
+			suggestion(
+				"Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour",
+			),
 		];
 	}),
 
 	requiredComponentInvalidType: errorWithContext((className: string, typeName: string) => {
 		return [
 			`@RequireComponent decorator on class '${className}' received invalid component type '${typeName}'`,
-			suggestion("Component type must be a Unity component or AirshipBehaviour. Try @RequireComponent<ValidComponentType>()"),
+			suggestion(
+				"Component type must be a Unity component or AirshipBehaviour. Try @RequireComponent<ValidComponentType>()",
+			),
 		];
 	}),
 
 	requiredComponentInvalidArgument: errorWithContext((className: string, argumentType: string) => {
 		return [
 			`@RequireComponent decorator on class '${className}' received invalid argument of type '${argumentType}'`,
-			suggestion("Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour"),
+			suggestion(
+				"Use @RequireComponent<ComponentType>() where ComponentType is a Unity component or AirshipBehaviour",
+			),
 		];
 	}),
 
@@ -310,6 +318,13 @@ export const errors = {
 		];
 	}),
 
+	directiveServerInvalid: error(
+		"$SERVER is a directive macro and can only be used as a top-level condition in an if statement - e.g. if ($SERVER)",
+	),
+	directiveClientInvalid: error(
+		"$CLIENT is a directive macro and can only be used as a top-level condition in an if statement - e.g. if ($CLIENT)",
+	),
+
 	flameworkIdNoType: errorWithContext(() => {
 		return [
 			"Macro Flamework.id<T> requires a type argument at T",
@@ -345,8 +360,6 @@ export const warnings = {
 	runtimeLibUsedInReplicatedFirst: warning(
 		"This statement would generate a call to the runtime library. The runtime library should not be used from ReplicatedFirst.",
 	),
-
-	contextMacro: warning("Directive used here will not strip code"),
 
 	dependencyInjectionDeprecated: warningWithContext((id: ts.Identifier) => {
 		return [

--- a/src/Shared/diagnostics.ts
+++ b/src/Shared/diagnostics.ts
@@ -244,6 +244,8 @@ export const errors = {
 		];
 	}),
 
+	invalidServerMacroUse:error("invalid"),
+
 	requiredComponentTypeParameterRequired: errorWithContext((className: string) => {
 		return [
 			`@RequireComponent decorator on class '${className}' requires at least one type parameter`,
@@ -343,6 +345,8 @@ export const warnings = {
 	runtimeLibUsedInReplicatedFirst: warning(
 		"This statement would generate a call to the runtime library. The runtime library should not be used from ReplicatedFirst.",
 	),
+
+	contextMacro: warning("Directive used here will not strip code"),
 
 	dependencyInjectionDeprecated: warningWithContext((id: ts.Identifier) => {
 		return [

--- a/src/Shared/types.ts
+++ b/src/Shared/types.ts
@@ -28,6 +28,7 @@ export interface ProjectOptions {
 	watch: boolean;
 	json: boolean;
 	publish: boolean;
+	skipPackages: boolean;
 	writeOnlyChanged: boolean;
 	optimizedLoops: boolean;
 	allowCommentDirectives: boolean;

--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -55,6 +55,9 @@ export const SYMBOL_NAMES = {
 
 	$range: "$range",
 	$tuple: "$tuple",
+
+	$SERVER: "$SERVER",
+	$CLIENT: "$CLIENT",
 } as const;
 
 export const NOMINAL_LUA_TUPLE_NAME = "_nominal_LuaTuple";

--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -1,9 +1,10 @@
+import path from "path";
 import { ProjectError } from "Shared/errors/ProjectError";
 import { assert } from "Shared/util/assert";
 import { CALL_MACROS } from "TSTransformer/macros/callMacros";
 import { CONSTRUCTOR_MACROS } from "TSTransformer/macros/constructorMacros";
 import { IDENTIFIER_MACROS } from "TSTransformer/macros/identifierMacros";
-import { PROPERTY_CALL_MACROS } from "TSTransformer/macros/propertyCallMacros";
+import { GAME_MACROS, PROPERTY_CALL_MACROS } from "TSTransformer/macros/propertyCallMacros";
 import {
 	CallDecoratorMacro,
 	CallMacro,
@@ -14,7 +15,7 @@ import {
 	PropertySetMacro,
 } from "TSTransformer/macros/types";
 import { skipUpwards } from "TSTransformer/util/traversal";
-import ts from "typescript";
+import ts, { MethodDeclaration } from "typescript";
 
 function getType(typeChecker: ts.TypeChecker, node: ts.Node) {
 	return typeChecker.getTypeAtLocation(skipUpwards(node));
@@ -126,7 +127,11 @@ export class MacroManager {
 	private macroOnlySymbols = new Set<ts.Symbol>();
 	private propertyMacros = new Map<ts.Symbol, PropertyMacro>();
 
-	constructor(private readonly typeChecker: ts.TypeChecker) {
+	public readonly isServerSymbol: ts.Symbol | undefined;
+	public readonly isClientSymbol: ts.Symbol | undefined;
+	public readonly isEditorSymbol: ts.Symbol | undefined;
+
+	constructor(private readonly typeChecker: ts.TypeChecker, private readonly program: ts.Program) {
 		for (const [name, macro] of Object.entries(IDENTIFIER_MACROS)) {
 			const symbol = getGlobalSymbolByNameOrThrow(typeChecker, name, ts.SymbolFlags.Variable);
 			this.identifierMacros.set(symbol, macro);
@@ -177,6 +182,35 @@ export class MacroManager {
 				this.symbols.set(symbolName, symbol);
 			} else {
 				throw new ProjectError(`The types for symbol '${symbolName}' could not be found` + TYPES_NOTICE);
+			}
+		}
+
+		/** Macros relating to Game */
+		const gameModuleDir = path.relative(process.cwd(), "AirshipPackages/@Easy/Core/Shared/Game.ts");
+		const gameModuleFile = program.getSourceFile(gameModuleDir);
+		if (gameModuleFile) {
+			const gameDeclaration = gameModuleFile.statements.find(
+				(f): f is ts.ClassDeclaration => ts.isClassDeclaration(f) && f.name?.text === "Game",
+			);
+
+			if (gameDeclaration) {
+				const isServer = gameDeclaration.members.find(
+					(f): f is MethodDeclaration & { name: ts.Identifier } =>
+						ts.isMethodDeclaration(f) && ts.isIdentifier(f.name) && f.name.text === "IsServer",
+				);
+				if (isServer) this.isServerSymbol = typeChecker.getSymbolAtLocation(isServer.name);
+
+				const isClient = gameDeclaration.members.find(
+					(f): f is MethodDeclaration & { name: ts.Identifier } =>
+						ts.isMethodDeclaration(f) && ts.isIdentifier(f.name) && f.name.text === "IsClient",
+				);
+				if (isClient) this.isClientSymbol = typeChecker.getSymbolAtLocation(isClient.name);
+
+				const isEditor = gameDeclaration.members.find(
+					(f): f is MethodDeclaration & { name: ts.Identifier } =>
+						ts.isMethodDeclaration(f) && ts.isIdentifier(f.name) && f.name.text === "IsEditor",
+				);
+				if (isEditor) this.isEditorSymbol = typeChecker.getSymbolAtLocation(isEditor.name);
 			}
 		}
 

--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -58,6 +58,8 @@ export const SYMBOL_NAMES = {
 
 	$SERVER: "$SERVER",
 	$CLIENT: "$CLIENT",
+	Server: "Server",
+	Client: "Client",
 } as const;
 
 export const NOMINAL_LUA_TUPLE_NAME = "_nominal_LuaTuple";
@@ -307,5 +309,15 @@ export class MacroManager {
 	public isPropertyCallMacro(symbol: ts.Symbol) {
 		const macro = this.propertyCallMacros.get(symbol);
 		return macro !== undefined;
+	}
+
+	public isDirective(symbol: ts.Symbol) {
+		return symbol === this.getSymbolOrThrow("$CLIENT") || symbol === this.getSymbolOrThrow("$SERVER");
+	}
+
+	public isDirectiveAtLocation(node: ts.Expression) {
+		const symbol = this.typeChecker.getSymbolAtLocation(node);
+		if (!symbol) return false;
+		return this.isDirective(symbol);
 	}
 }

--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -4,7 +4,7 @@ import { assert } from "Shared/util/assert";
 import { CALL_MACROS } from "TSTransformer/macros/callMacros";
 import { CONSTRUCTOR_MACROS } from "TSTransformer/macros/constructorMacros";
 import { IDENTIFIER_MACROS } from "TSTransformer/macros/identifierMacros";
-import { GAME_MACROS, PROPERTY_CALL_MACROS } from "TSTransformer/macros/propertyCallMacros";
+import { PROPERTY_CALL_MACROS } from "TSTransformer/macros/propertyCallMacros";
 import {
 	CallDecoratorMacro,
 	CallMacro,

--- a/src/TSTransformer/classes/MacroManager.ts
+++ b/src/TSTransformer/classes/MacroManager.ts
@@ -130,6 +130,8 @@ export class MacroManager {
 	public readonly isServerSymbol: ts.Symbol | undefined;
 	public readonly isClientSymbol: ts.Symbol | undefined;
 	public readonly isEditorSymbol: ts.Symbol | undefined;
+	public readonly $SERVER: ts.Symbol;
+	public readonly $CLIENT: ts.Symbol;
 
 	constructor(private readonly typeChecker: ts.TypeChecker, private readonly program: ts.Program) {
 		for (const [name, macro] of Object.entries(IDENTIFIER_MACROS)) {
@@ -225,6 +227,9 @@ export class MacroManager {
 				this.symbols.set(NOMINAL_LUA_TUPLE_NAME, nominalLuaTupleSymbol);
 			}
 		}
+
+		this.$SERVER = this.getSymbolOrThrow("$SERVER");
+		this.$CLIENT = this.getSymbolOrThrow("$CLIENT");
 	}
 
 	public isMacroOnlySymbol(symbol: ts.Symbol) {

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -76,10 +76,11 @@ export class TransformState {
 	// 	this._context = value;
 	// }
 
-	public useContext(context: CompliationContext, action: (context: CompliationContext) => void) {
+	public useContext<R = void>(context: CompliationContext, action: (context: CompliationContext) => R) {
 		this._context = context;
-		action(context);
+		const value = action(context);
 		this._context = CompliationContext.Shared;
+		return value;
 	}
 
 	constructor(

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -101,6 +101,22 @@ export class TransformState {
 		this.resolver = typeChecker.getEmitResolver(sourceFile);
 	}
 
+	private guardClauses = new Array<ts.IfStatement>();
+	public pushDirectiveStatement(statement: ts.IfStatement) {
+		console.log("push", statement.id);
+		this.guardClauses.push(statement);
+	}
+
+	public isDirectiveStatement(statement: ts.IfStatement) {
+		console.log("check", statement.id)
+		return this.guardClauses.includes(statement);
+	}
+
+	public popDirectiveStatement() {
+		console.log("pop");
+		return this.guardClauses.pop();
+	}
+
 	public readonly tryUsesStack = new Array<TryUses>();
 
 	/**

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -101,22 +101,6 @@ export class TransformState {
 		this.resolver = typeChecker.getEmitResolver(sourceFile);
 	}
 
-	private guardClauses = new Array<ts.IfStatement>();
-	public pushDirectiveStatement(statement: ts.IfStatement) {
-		console.log("push", statement.id);
-		this.guardClauses.push(statement);
-	}
-
-	public isDirectiveStatement(statement: ts.IfStatement) {
-		console.log("check", statement.id)
-		return this.guardClauses.includes(statement);
-	}
-
-	public popDirectiveStatement() {
-		console.log("pop");
-		return this.guardClauses.pop();
-	}
-
 	public readonly tryUsesStack = new Array<TryUses>();
 
 	/**

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -54,35 +54,6 @@ export class TransformState {
 
 	public readonly resolver: ts.EmitResolver;
 
-	private _context = CompliationContext.Shared;
-	public get context() {
-		return this._context;
-	}
-
-	public get isServerContext() {
-		return this._context === CompliationContext.Server;
-	}
-
-	public get isClientContext() {
-		return this._context === CompliationContext.Client;
-	}
-
-	public get isSharedContext() {
-		return this._context === CompliationContext.Shared;
-	}
-
-	// public set context(value: CompliationContext) {
-	// 	console.log("changed context to", CompliationContext[value]);
-	// 	this._context = value;
-	// }
-
-	public useContext<R = void>(context: CompliationContext, action: (context: CompliationContext) => R) {
-		this._context = context;
-		const value = action(context);
-		this._context = CompliationContext.Shared;
-		return value;
-	}
-
 	constructor(
 		public readonly program: ts.Program,
 		public readonly data: ProjectData,
@@ -103,6 +74,34 @@ export class TransformState {
 	}
 
 	public readonly tryUsesStack = new Array<TryUses>();
+
+	private _context = CompliationContext.Shared;
+	public get context() {
+		return this._context;
+	}
+
+	public get isServerContext() {
+		return this._context === CompliationContext.Server;
+	}
+
+	public get isClientContext() {
+		return this._context === CompliationContext.Client;
+	}
+
+	public get isSharedContext() {
+		return this._context === CompliationContext.Shared;
+	}
+
+	public get isPublish() {
+		return this.data.isPublishing;
+	}
+
+	public useContext<R = void>(context: CompliationContext, action: (context: CompliationContext) => R) {
+		this._context = context;
+		const value = action(context);
+		this._context = CompliationContext.Shared;
+		return value;
+	}
 
 	/**
 	 * Pushes tryUses information onto the tryUses stack and returns it.

--- a/src/TSTransformer/classes/TransformState.ts
+++ b/src/TSTransformer/classes/TransformState.ts
@@ -15,6 +15,21 @@ import ts from "typescript";
 
 export const SINGLETON_FILE_IMPORT = "AirshipPackages/@Easy/Core/Shared/Singletons/Singletons";
 
+export enum CompliationContext {
+	/**
+	 * Compiling for the server
+	 */
+	Server,
+	/**
+	 * Compiling for the client
+	 */
+	Client,
+	/**
+	 * Compiling for editor or packages
+	 */
+	Shared,
+}
+
 /**
  * Represents the state of the transformation between TS -> Luau AST.
  */
@@ -38,6 +53,34 @@ export class TransformState {
 	}
 
 	public readonly resolver: ts.EmitResolver;
+
+	private _context = CompliationContext.Shared;
+	public get context() {
+		return this._context;
+	}
+
+	public get isServerContext() {
+		return this._context === CompliationContext.Server;
+	}
+
+	public get isClientContext() {
+		return this._context === CompliationContext.Client;
+	}
+
+	public get isSharedContext() {
+		return this._context === CompliationContext.Shared;
+	}
+
+	// public set context(value: CompliationContext) {
+	// 	console.log("changed context to", CompliationContext[value]);
+	// 	this._context = value;
+	// }
+
+	public useContext(context: CompliationContext, action: (context: CompliationContext) => void) {
+		this._context = context;
+		action(context);
+		this._context = CompliationContext.Shared;
+	}
 
 	constructor(
 		public readonly program: ts.Program,

--- a/src/TSTransformer/macros/identifierMacros.ts
+++ b/src/TSTransformer/macros/identifierMacros.ts
@@ -34,8 +34,9 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 		} else if (state.isClientContext) {
 			return luau.bool(false);
 		} else {
+			const id = state.addFileImport("AirshipPackages/@Easy/Core/Shared/Game", "Game");
 			return luau.create(luau.SyntaxKind.MethodCallExpression, {
-				expression: luau.id("Game"),
+				expression: id,
 				name: "IsServer",
 				args: luau.list.make(),
 			});
@@ -53,8 +54,9 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 		} else if (state.isServerContext) {
 			return luau.bool(false);
 		} else {
+			const id = state.addFileImport("AirshipPackages/@Easy/Core/Shared/Game", "Game");
 			return luau.create(luau.SyntaxKind.MethodCallExpression, {
-				expression: luau.id("Game"),
+				expression: id,
 				name: "IsClient",
 				args: luau.list.make(),
 			});

--- a/src/TSTransformer/macros/identifierMacros.ts
+++ b/src/TSTransformer/macros/identifierMacros.ts
@@ -23,4 +23,34 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 
 		return luau.id("gameObject");
 	},
+
+	$SERVER: (state, node) => {
+		// return state.isServer ? true : state.isClient ? false  ? luau.call(luau.property(luau.id("Game"), "IsServer");
+		if (state.isServerContext) {
+			return luau.bool(true);
+		} else if (state.isClientContext) {
+			return luau.bool(false);
+		} else {
+			return luau.create(luau.SyntaxKind.MethodCallExpression, {
+				expression: luau.id("Game"),
+				name: "IsServer",
+				args: luau.list.make(),
+			});
+		}
+	},
+
+	$CLIENT: (state, node) => {
+		// return state.isServer ? true : state.isClient ? false  ? luau.call(luau.property(luau.id("Game"), "IsServer");
+		if (state.isClientContext) {
+			return luau.bool(true);
+		} else if (state.isServerContext) {
+			return luau.bool(false);
+		} else {
+			return luau.create(luau.SyntaxKind.MethodCallExpression, {
+				expression: luau.id("Game"),
+				name: "IsClient",
+				args: luau.list.make(),
+			});
+		}
+	},
 };

--- a/src/TSTransformer/macros/identifierMacros.ts
+++ b/src/TSTransformer/macros/identifierMacros.ts
@@ -32,8 +32,7 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 
 	$SERVER: (state, node) => {
 		if (!isValidDirectiveParent(node.parent) && !state.isSharedContext) {
-
-			DiagnosticService.addDiagnostic(errors.directiveClientInvalid(node.parent));
+			DiagnosticService.addDiagnostic(errors.directiveServerInvalid(node.parent));
 		}
 
 		if (state.isServerContext) {
@@ -54,7 +53,6 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 		// DiagnosticService.addDiagnostic(errors.invalidServerMacroUse(node));
 
 		if (!isValidDirectiveParent(node.parent) && !state.isSharedContext) {
-			console.log(ts.SyntaxKind[node.parent.kind])
 			DiagnosticService.addDiagnostic(errors.directiveClientInvalid(node.parent));
 		}
 

--- a/src/TSTransformer/macros/identifierMacros.ts
+++ b/src/TSTransformer/macros/identifierMacros.ts
@@ -27,9 +27,8 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 	},
 
 	$SERVER: (state, node) => {
-		if (!ts.isIfStatement(node.parent)) DiagnosticService.addDiagnostic(warnings.contextMacro(node));
+		if (!ts.isIfStatement(node.parent)) DiagnosticService.addDiagnostic(errors.directiveServerInvalid(node));
 
-		// return state.isServer ? true : state.isClient ? false  ? luau.call(luau.property(luau.id("Game"), "IsServer");
 		if (state.isServerContext) {
 			return luau.bool(true);
 		} else if (state.isClientContext) {
@@ -45,7 +44,8 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 
 	$CLIENT: (state, node) => {
 		// DiagnosticService.addDiagnostic(errors.invalidServerMacroUse(node));
-		// DiagnosticService.addDiagnostic(warnings.contextMacro(node));
+
+		if (!ts.isIfStatement(node.parent)) DiagnosticService.addDiagnostic(errors.directiveClientInvalid(node.parent));
 
 		// return state.isServer ? true : state.isClient ? false  ? luau.call(luau.property(luau.id("Game"), "IsServer");
 		if (state.isClientContext) {

--- a/src/TSTransformer/macros/identifierMacros.ts
+++ b/src/TSTransformer/macros/identifierMacros.ts
@@ -1,4 +1,6 @@
 import luau from "@roblox-ts/luau-ast";
+import { errors, warnings } from "Shared/diagnostics";
+import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { IdentifierMacro, MacroList } from "TSTransformer/macros/types";
 import { isAirshipBehaviourClass } from "TSTransformer/util/extendsAirshipBehaviour";
 import ts from "typescript";
@@ -25,6 +27,8 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 	},
 
 	$SERVER: (state, node) => {
+		if (!ts.isIfStatement(node.parent)) DiagnosticService.addDiagnostic(warnings.contextMacro(node));
+
 		// return state.isServer ? true : state.isClient ? false  ? luau.call(luau.property(luau.id("Game"), "IsServer");
 		if (state.isServerContext) {
 			return luau.bool(true);
@@ -40,6 +44,9 @@ export const IDENTIFIER_MACROS: MacroList<IdentifierMacro> = {
 	},
 
 	$CLIENT: (state, node) => {
+		// DiagnosticService.addDiagnostic(errors.invalidServerMacroUse(node));
+		// DiagnosticService.addDiagnostic(warnings.contextMacro(node));
+
 		// return state.isServer ? true : state.isClient ? false  ? luau.call(luau.property(luau.id("Game"), "IsServer");
 		if (state.isClientContext) {
 			return luau.bool(true);

--- a/src/TSTransformer/macros/transformContextMethods.ts
+++ b/src/TSTransformer/macros/transformContextMethods.ts
@@ -45,14 +45,12 @@ export function createStripMethod(
 						luau.string(
 							`Attempted to call ${state.isClientContext ? "server" : "client"}-only method '${
 								name.value
-							}'!`,
+							}' from the ${state.isServerContext ? "server" : "client"}!`,
 						),
 						luau.number(2),
 					]),
 				}),
 			);
-		} else {
-			luau.list.push(methodBody, luau.comment(" ► Method has no expected return values"));
 		}
 
 		luau.list.push(
@@ -100,13 +98,14 @@ export function createStripReturn(
 		);
 	}
 
+	const id = state.addFileImport("AirshipPackages/@Easy/Core/Shared/Game", "Game");
 	luau.list.push(
 		statements,
 		luau.create(luau.SyntaxKind.IfStatement, {
 			statements: methodStatements,
 			condition: luau.create(luau.SyntaxKind.UnaryExpression, {
 				expression: luau.create(luau.SyntaxKind.MethodCallExpression, {
-					expression: luau.id("Game"),
+					expression: id,
 					name: context === CompliationContext.Server ? "IsServer" : "IsClient",
 					args: luau.list.make(),
 				}),

--- a/src/TSTransformer/macros/transformContextMethods.ts
+++ b/src/TSTransformer/macros/transformContextMethods.ts
@@ -1,0 +1,114 @@
+import luau from "@roblox-ts/luau-ast";
+import { CompliationContext, TransformState } from "TSTransformer/classes/TransformState";
+import { transformPropertyName } from "TSTransformer/nodes/transformPropertyName";
+import ts from "typescript";
+
+export function hasDecoratorByName(state: TransformState, decorators: Array<ts.Decorator>, name: "Client" | "Server") {
+	const symbol = state.services.macroManager.getSymbolOrThrow(name);
+
+	for (const { expression } of decorators) {
+		if (!ts.isCallExpression(expression)) continue;
+		if (!ts.isIdentifier(expression.expression)) continue;
+
+		const symbolOfExpression = state.typeChecker.getSymbolAtLocation(expression.expression);
+		if (symbolOfExpression === symbol) return true;
+	}
+
+	return false;
+}
+
+export function createStripMethod(
+	state: TransformState,
+	method: ts.MethodDeclaration,
+	internalName: luau.AnyIdentifier,
+): luau.List<luau.Statement> {
+	const statements = luau.list.make<luau.Statement>();
+	const name = transformPropertyName(state, method.name);
+
+	if (luau.isStringLiteral(name)) {
+		luau.list.push(
+			statements,
+			luau.create(luau.SyntaxKind.MethodDeclaration, {
+				expression: internalName,
+				name: name.value,
+				parameters: luau.list.make(),
+				statements: luau.list.make<luau.Statement>(
+					luau.create(luau.SyntaxKind.CallStatement, {
+						expression: luau.call(luau.globals.error, [
+							luau.string(`Attempt to call context stripped method '${name.value}'`),
+							luau.number(2),
+						]),
+					}),
+				),
+				hasDotDotDot: true,
+			}),
+		);
+	}
+
+	return statements;
+}
+
+export function createStripReturn(
+	state: TransformState,
+	name: string,
+	context: CompliationContext,
+): luau.List<luau.Statement> {
+	const statements = luau.list.make<luau.Statement>();
+
+	luau.list.push(
+		statements,
+		luau.create(luau.SyntaxKind.IfStatement, {
+			statements: luau.list.make<luau.Statement>(
+				luau.create(luau.SyntaxKind.CallStatement, {
+					expression: luau.call(luau.globals.error, [
+						luau.string(`Attempt to call context stripped method '${name}'`),
+						luau.number(2),
+					]),
+				}),
+				// luau.create(luau.SyntaxKind.ReturnStatement, { expression: luau.nil() }),
+			),
+			condition: luau.create(luau.SyntaxKind.UnaryExpression, {
+				expression: luau.create(luau.SyntaxKind.MethodCallExpression, {
+					expression: luau.id("Game"),
+					name: context === CompliationContext.Server ? "IsServer" : "IsClient",
+					args: luau.list.make(),
+				}),
+				operator: "not",
+			}),
+			elseBody: luau.list.make(),
+		}),
+	);
+
+	return statements;
+}
+
+export function getStrippableMethodType(
+	state: TransformState,
+	method: ts.MethodDeclaration,
+): CompliationContext | undefined {
+	if (!method.modifiers) return;
+	const decorators = method.modifiers?.filter(f => ts.isDecorator(f));
+	if (!decorators) return;
+
+	if (hasDecoratorByName(state, decorators, "Server") && !state.isServerContext) {
+		return CompliationContext.Server;
+	} else if (hasDecoratorByName(state, decorators, "Client") && !state.isClientContext) {
+		return CompliationContext.Client;
+	}
+
+	return;
+}
+
+export function isStrippableContextMethod(state: TransformState, method: ts.MethodDeclaration) {
+	if (!method.modifiers) return;
+	const decorators = method.modifiers?.filter(f => ts.isDecorator(f));
+	if (!decorators) return false;
+
+	if (hasDecoratorByName(state, decorators, "Server") && !state.isServerContext) {
+		return true;
+	} else if (hasDecoratorByName(state, decorators, "Client") && !state.isClientContext) {
+		return true;
+	}
+
+	return false;
+}

--- a/src/TSTransformer/macros/transformDirectives.ts
+++ b/src/TSTransformer/macros/transformDirectives.ts
@@ -1,0 +1,61 @@
+import luau from "@roblox-ts/luau-ast";
+import { TransformState } from "TSTransformer/classes/TransformState";
+import { transformStatement } from "TSTransformer/nodes/statements/transformStatement";
+import ts from "typescript";
+
+function containsServerCheckDirective(state: TransformState, node: ts.IfStatement) {
+	if (ts.isIdentifier(node.expression)) {
+		const symbol = state.typeChecker.getSymbolAtLocation(node.expression);
+		if (!symbol) return false;
+
+		return state.services.macroManager.getSymbolOrThrow("$SERVER") === symbol;
+	} else if (
+		ts.isPrefixUnaryExpression(node.expression) &&
+		node.expression.operator === ts.SyntaxKind.ExclamationToken
+	) {
+		const symbol = state.typeChecker.getSymbolAtLocation(node.expression.operand);
+		if (!symbol) return false;
+		return state.services.macroManager.getSymbolOrThrow("$CLIENT") === symbol;
+	}
+
+	return false;
+}
+
+function containsClientCheckDirective(state: TransformState, node: ts.IfStatement) {
+	if (ts.isIdentifier(node.expression)) {
+		const symbol = state.typeChecker.getSymbolAtLocation(node.expression);
+		if (!symbol) return false;
+
+		return state.services.macroManager.getSymbolOrThrow("$CLIENT") === symbol;
+	} else if (
+		ts.isPrefixUnaryExpression(node.expression) &&
+		node.expression.operator === ts.SyntaxKind.ExclamationToken
+	) {
+		const symbol = state.typeChecker.getSymbolAtLocation(node.expression.operand);
+		if (!symbol) return false;
+		return state.services.macroManager.getSymbolOrThrow("$SERVER") === symbol;
+	}
+
+	return false;
+}
+
+export function transformDirectiveIfStatement(
+	state: TransformState,
+	node: ts.IfStatement,
+): ts.Statement | false | undefined {
+	if (containsServerCheckDirective(state, node)) {
+		// we're in contextual mode
+		if (state.isServerContext) {
+			return node.thenStatement;
+		} else {
+			return node.elseStatement ?? false;
+		}
+	} else if (containsClientCheckDirective(state, node)) {
+		// we're in contextual mode
+		if (state.isClientContext) {
+			return node.thenStatement;
+		} else {
+			return node.elseStatement ?? false;
+		}
+	}
+}

--- a/src/TSTransformer/macros/transformDirectives.ts
+++ b/src/TSTransformer/macros/transformDirectives.ts
@@ -103,7 +103,10 @@ export function isEditorIfDirective(state: TransformState, node: ts.IfStatement)
 
 function isReturning(state: TransformState, statement: ts.Statement) {
 	if (ts.isBlock(statement)) {
-		return ts.isReturnStatement(statement.statements[statement.statements.length - 1]);
+		return (
+			statement.statements.length > 0 &&
+			ts.isReturnStatement(statement.statements[statement.statements.length - 1])
+		);
 	} else if (ts.isReturnStatement(statement)) {
 		return true;
 	}
@@ -113,7 +116,10 @@ function isReturning(state: TransformState, statement: ts.Statement) {
 
 function isThrowing(state: TransformState, statement: ts.Statement) {
 	if (ts.isBlock(statement)) {
-		return ts.isThrowStatement(statement.statements[statement.statements.length - 1]);
+		return (
+			statement.statements.length > 0 &&
+			ts.isThrowStatement(statement.statements[statement.statements.length - 1])
+		);
 	} else if (ts.isThrowStatement(statement)) {
 		return true;
 	}
@@ -126,6 +132,18 @@ export function isGuardClause(state: TransformState, node: ts.IfStatement) {
 	if (
 		(isServerIfDirective(state, node) || isClientIfDirective(state, node)) &&
 		(isReturning(state, node.thenStatement) || isThrowing(state, node.thenStatement))
+	) {
+		return true;
+	}
+
+	return false;
+}
+
+export function isInverseGuardClause(state: TransformState, node: ts.IfStatement) {
+	if (
+		node.elseStatement &&
+		(isServerIfDirective(state, node) || isClientIfDirective(state, node)) &&
+		(isReturning(state, node.elseStatement) || isThrowing(state, node.elseStatement))
 	) {
 		return true;
 	}

--- a/src/TSTransformer/macros/transformDirectives.ts
+++ b/src/TSTransformer/macros/transformDirectives.ts
@@ -82,7 +82,6 @@ export function transformDirectiveIfStatement(
 	ignoreGuard = false,
 ): ts.Statement | false | undefined {
 	if (isGuardClause(state, node) && !ignoreGuard) {
-		state.pushDirectiveStatement(node);
 		return undefined;
 	}
 

--- a/src/TSTransformer/macros/transformDirectives.ts
+++ b/src/TSTransformer/macros/transformDirectives.ts
@@ -1,5 +1,5 @@
 import { TransformState } from "TSTransformer/classes/TransformState";
-import ts, { factory } from "typescript";
+import ts from "typescript";
 
 function isExclamationUnaryExpression(
 	node: ts.Expression,

--- a/src/TSTransformer/macros/transformDirectives.ts
+++ b/src/TSTransformer/macros/transformDirectives.ts
@@ -171,27 +171,34 @@ export function transformDirectiveIfStatement(
 	state: TransformState,
 	node: ts.IfStatement,
 	ignoreGuard = false,
+	inverse = false,
 ): ts.Statement | false | undefined {
 	if (isGuardClause(state, node) && !ignoreGuard) {
 		return undefined;
 	}
 
 	if (isServerIfDirective(state, node)) {
+		const useThenStatement = inverse ? !state.isServerContext : state.isServerContext;
+
 		// we're in contextual mode
-		if (state.isServerContext) {
+		if (useThenStatement) {
 			return transformThenStatement(state, node);
 		} else {
 			return transformElseStatement(state, node); // node.elseStatement ?? false;
 		}
 	} else if (isClientIfDirective(state, node)) {
+		const useThenStatement = inverse ? !state.isClientContext : state.isClientContext;
+
 		// we're in contextual mode
-		if (state.isClientContext) {
+		if (useThenStatement) {
 			return transformThenStatement(state, node);
 		} else {
 			return transformElseStatement(state, node); //node.elseStatement ?? false;
 		}
 	} else if (isEditorIfDirective(state, node)) {
-		if (state.isPublish) {
+		const useThenStatement = inverse ? !state.isPublish : state.isPublish;
+
+		if (useThenStatement) {
 			return transformElseStatement(state, node); //node.elseStatement ?? false;
 		} else {
 			return transformThenStatement(state, node);

--- a/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
+++ b/src/TSTransformer/nodes/class/transformClassLikeDeclaration.ts
@@ -19,6 +19,7 @@ import { assert } from "Shared/util/assert";
 import { SYMBOL_NAMES, TransformState } from "TSTransformer";
 import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import { isAirshipBehaviourReserved } from "TSTransformer/macros/propertyMacros";
+import { createStripMethod, isStrippableContextMethod } from "TSTransformer/macros/transformContextMethods";
 import { transformClassConstructor } from "TSTransformer/nodes/class/transformClassConstructor";
 import { transformDecorators } from "TSTransformer/nodes/class/transformDecorators";
 import { transformPropertyDeclaration } from "TSTransformer/nodes/class/transformPropertyDeclaration";
@@ -54,8 +55,6 @@ import { getOriginalSymbolOfNode } from "TSTransformer/util/getOriginalSymbolOfN
 import { validateIdentifier } from "TSTransformer/util/validateIdentifier";
 import { validateMethodAssignment } from "TSTransformer/util/validateMethodAssignment";
 import ts, { JSDoc, JSDocComment, JSDocTag, ModifierFlags } from "typescript";
-import { transformPropertyName } from "../transformPropertyName";
-import { createStripMethod, isStrippableContextMethod } from "TSTransformer/macros/transformContextMethods";
 
 const MAGIC_TO_STRING_METHOD = "toString";
 

--- a/src/TSTransformer/nodes/statements/transformIfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformIfStatement.ts
@@ -8,8 +8,6 @@ import { createTruthinessChecks } from "TSTransformer/util/createTruthinessCheck
 import { getStatements } from "TSTransformer/util/getStatements";
 import ts from "typescript";
 
-
-
 export function transformIfStatementInner(state: TransformState, node: ts.IfStatement): luau.IfStatement {
 	const condition = createTruthinessChecks(state, transformExpression(state, node.expression), node.expression);
 

--- a/src/TSTransformer/nodes/statements/transformIfStatement.ts
+++ b/src/TSTransformer/nodes/statements/transformIfStatement.ts
@@ -1,10 +1,14 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
+import { transformDirectiveIfStatement as tryTransformContextDirectives } from "TSTransformer/macros/transformDirectives";
 import { transformExpression } from "TSTransformer/nodes/expressions/transformExpression";
+import { transformStatement } from "TSTransformer/nodes/statements/transformStatement";
 import { transformStatementList } from "TSTransformer/nodes/transformStatementList";
 import { createTruthinessChecks } from "TSTransformer/util/createTruthinessChecks";
 import { getStatements } from "TSTransformer/util/getStatements";
 import ts from "typescript";
+
+
 
 export function transformIfStatementInner(state: TransformState, node: ts.IfStatement): luau.IfStatement {
 	const condition = createTruthinessChecks(state, transformExpression(state, node.expression), node.expression);
@@ -37,6 +41,15 @@ export function transformIfStatementInner(state: TransformState, node: ts.IfStat
 	});
 }
 
-export function transformIfStatement(state: TransformState, node: ts.IfStatement) {
+export function transformIfStatement(state: TransformState, node: ts.IfStatement): luau.List<luau.Statement> {
+	if (!state.isSharedContext) {
+		const directive = tryTransformContextDirectives(state, node);
+		if (directive) {
+			return transformStatement(state, directive);
+		} else if (directive === false) {
+			return luau.list.make();
+		}
+	}
+
 	return luau.list.make(transformIfStatementInner(state, node));
 }

--- a/src/TSTransformer/nodes/transformMethodDeclaration.ts
+++ b/src/TSTransformer/nodes/transformMethodDeclaration.ts
@@ -52,13 +52,14 @@ export function transformMethodDeclaration(
 	}
 
 	const isAsync = !!ts.getSelectedSyntacticModifierFlags(node, ts.ModifierFlags.Async);
+	const isStrippable = isStrippableContextMethod(state, node);
 
-	if (isStrippableContextMethod(state, node)) {
+	if (isStrippable) {
 		const contextType = getStrippableMethodType(state, node);
 		if (contextType !== undefined) {
 			luau.list.unshiftList(
 				statements,
-				createStripReturn(state, luau.isStringLiteral(name) ? name.value : "", contextType),
+				createStripReturn(state, luau.isStringLiteral(name) ? name.value : "", node, contextType),
 			);
 		}
 	}

--- a/src/TSTransformer/nodes/transformStatementList.ts
+++ b/src/TSTransformer/nodes/transformStatementList.ts
@@ -1,8 +1,8 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
 import {
-	containsClientCheckDirective,
-	containsServerCheckDirective,
+	isClientDirective,
+	isServerDirective,
 	isGuardClause,
 	transformDirectiveIfStatement,
 } from "TSTransformer/macros/transformDirectives";
@@ -33,13 +33,14 @@ export function transformStatementList(
 
 		if (!state.isSharedContext && ts.isIfStatement(statement)) {
 			if (isGuardClause(state, statement)) {
-				if (state.isServerContext && containsServerCheckDirective(state, statement)) {
+				state.pushDirectiveStatement(statement);
+				if (state.isServerContext && isServerDirective(state, statement)) {
 					shouldEarlyReturn = true;
 					const newStatement = transformDirectiveIfStatement(state, statement, true);
 					if (newStatement) {
 						statement = newStatement;
 					}
-				} else if (state.isClientContext && containsClientCheckDirective(state, statement)) {
+				} else if (state.isClientContext && isClientDirective(state, statement)) {
 					shouldEarlyReturn = true;
 					const newStatement = transformDirectiveIfStatement(state, statement, true);
 					if (newStatement) {

--- a/src/TSTransformer/nodes/transformStatementList.ts
+++ b/src/TSTransformer/nodes/transformStatementList.ts
@@ -1,10 +1,14 @@
 import luau from "@roblox-ts/luau-ast";
+import { stat } from "fs";
+import { errors } from "Shared/diagnostics";
 import { TransformState } from "TSTransformer";
+import { DiagnosticService } from "TSTransformer/classes/DiagnosticService";
 import {
 	isClientIfDirective,
 	isServerIfDirective,
 	isGuardClause,
 	transformDirectiveIfStatement,
+	isInverseGuardClause,
 } from "TSTransformer/macros/transformDirectives";
 import { transformStatement } from "TSTransformer/nodes/statements/transformStatement";
 import { createHoistDeclaration } from "TSTransformer/util/createHoistDeclaration";
@@ -48,6 +52,8 @@ export function transformStatementList(
 				} else {
 					continue;
 				}
+			} else if (isInverseGuardClause(state, statement)) {
+				DiagnosticService.addDiagnostic(errors.inverseGuardClause(statement));
 			}
 		}
 

--- a/src/TSTransformer/nodes/transformStatementList.ts
+++ b/src/TSTransformer/nodes/transformStatementList.ts
@@ -53,7 +53,21 @@ export function transformStatementList(
 					continue;
 				}
 			} else if (isInverseGuardClause(state, statement)) {
-				DiagnosticService.addDiagnostic(errors.inverseGuardClause(statement));
+				if (state.isClientContext && isServerIfDirective(state, statement)) {
+					shouldEarlyReturn = true;
+					const newStatement = transformDirectiveIfStatement(state, statement, true);
+					if (newStatement) {
+						statement = newStatement;
+					}
+				} else if (state.isServerContext && isClientIfDirective(state, statement)) {
+					shouldEarlyReturn = true;
+					const newStatement = transformDirectiveIfStatement(state, statement, true);
+					if (newStatement) {
+						statement = newStatement;
+					}
+				} else {
+					continue;
+				}
 			}
 		}
 

--- a/src/TSTransformer/nodes/transformStatementList.ts
+++ b/src/TSTransformer/nodes/transformStatementList.ts
@@ -1,8 +1,8 @@
 import luau from "@roblox-ts/luau-ast";
 import { TransformState } from "TSTransformer";
 import {
-	isClientDirective,
-	isServerDirective,
+	isClientIfDirective,
+	isServerIfDirective,
 	isGuardClause,
 	transformDirectiveIfStatement,
 } from "TSTransformer/macros/transformDirectives";
@@ -33,13 +33,13 @@ export function transformStatementList(
 
 		if (!state.isSharedContext && ts.isIfStatement(statement)) {
 			if (isGuardClause(state, statement)) {
-				if (state.isServerContext && isServerDirective(state, statement)) {
+				if (state.isServerContext && isServerIfDirective(state, statement)) {
 					shouldEarlyReturn = true;
 					const newStatement = transformDirectiveIfStatement(state, statement, true);
 					if (newStatement) {
 						statement = newStatement;
 					}
-				} else if (state.isClientContext && isClientDirective(state, statement)) {
+				} else if (state.isClientContext && isClientIfDirective(state, statement)) {
 					shouldEarlyReturn = true;
 					const newStatement = transformDirectiveIfStatement(state, statement, true);
 					if (newStatement) {

--- a/src/TSTransformer/nodes/transformStatementList.ts
+++ b/src/TSTransformer/nodes/transformStatementList.ts
@@ -33,7 +33,6 @@ export function transformStatementList(
 
 		if (!state.isSharedContext && ts.isIfStatement(statement)) {
 			if (isGuardClause(state, statement)) {
-				state.pushDirectiveStatement(statement);
 				if (state.isServerContext && isServerDirective(state, statement)) {
 					shouldEarlyReturn = true;
 					const newStatement = transformDirectiveIfStatement(state, statement, true);

--- a/src/TSTransformer/util/createTransformServices.ts
+++ b/src/TSTransformer/util/createTransformServices.ts
@@ -8,9 +8,7 @@ export function createTransformServices(
 	typeChecker: ts.TypeChecker,
 	data: ProjectData,
 ): TransformServices {
-	const macroManager = new MacroManager(typeChecker);
-
-	// const roactSymbolManager = RoactSymbolManager.create(data, program, typeChecker);
+	const macroManager = new MacroManager(typeChecker, program);
 	const airshipSymbolManager = new AirshipSymbolManager(typeChecker, macroManager);
 
 	return { macroManager, roactSymbolManager: undefined, airshipSymbolManager };


### PR DESCRIPTION
Adds the following macros:
`$SERVER` - server directive
`$CLIENT` - client directive

`Game.IsServer()`, `Game.IsClient()` - implicit branches

Adds the following macro decorators
`@Server()` - Marks a method as server-only
`@Client()` - Marks a method as client-only